### PR TITLE
Implement remaining CurveVM opcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ from src.compiler import compile_program
 from src.curvevm import CurveVM
 from src.rollup import BatchPoster, FakeSolanaClient
 
-script = "BUY 5"
+script = """BUY 5\nSELL 2\nADD_LIQUIDITY 3\nMIGRATE_TO_AMM 1"""
 program = compile_program(parse(script))
 vm = CurveVM()
 vm.execute(program)

--- a/src/compiler.py
+++ b/src/compiler.py
@@ -11,8 +11,10 @@ class Instruction:
 def compile_program(commands: List[Command]) -> List[Instruction]:
     """Compile a list of Commands into CurveVM instructions."""
     instructions: List[Instruction] = []
+    allowed = {"BUY", "SELL", "ADD_LIQUIDITY", "MIGRATE_TO_AMM"}
     for cmd in commands:
-        if cmd.opcode.upper() != "BUY":
+        op = cmd.opcode.upper()
+        if op not in allowed:
             raise ValueError(f"Unknown command: {cmd.opcode}")
-        instructions.append(Instruction(opcode="BUY", operand=cmd.operand))
+        instructions.append(Instruction(opcode=op, operand=cmd.operand))
     return instructions

--- a/src/curvescript.py
+++ b/src/curvescript.py
@@ -8,18 +8,19 @@ class Command:
 
 
 def parse(script: str) -> List[Command]:
-    """Parse a tiny CurveScript consisting only of BUY commands."""
+    """Parse a tiny CurveScript supporting four opcodes."""
     commands: List[Command] = []
+    allowed = {"BUY", "SELL", "ADD_LIQUIDITY", "MIGRATE_TO_AMM"}
     for line in script.strip().splitlines():
         line = line.strip()
         if not line:
             continue
         parts = line.split()
-        if len(parts) != 2 or parts[0].upper() != "BUY":
+        if len(parts) != 2 or parts[0].upper() not in allowed:
             raise ValueError(f"Invalid statement: {line}")
         try:
             amount = int(parts[1])
         except ValueError as e:
             raise ValueError(f"Invalid amount in: {line}") from e
-        commands.append(Command(opcode="BUY", operand=amount))
+        commands.append(Command(opcode=parts[0].upper(), operand=amount))
     return commands

--- a/src/curvevm.py
+++ b/src/curvevm.py
@@ -3,14 +3,25 @@ from .compiler import Instruction
 
 
 class CurveVM:
-    """A minimal VM supporting only the BUY opcode."""
+    """A minimal VM supporting four opcodes."""
 
     def __init__(self) -> None:
         self.balance = 0
+        self.liquidity = 0
+        self.migrated_to_amm = False
+        self.migrate_value = 0
 
     def execute(self, program: List[Instruction]) -> None:
         for ins in program:
-            if ins.opcode.upper() == "BUY":
+            op = ins.opcode.upper()
+            if op == "BUY":
                 self.balance += ins.operand
+            elif op == "SELL":
+                self.balance -= ins.operand
+            elif op == "ADD_LIQUIDITY":
+                self.liquidity += ins.operand
+            elif op == "MIGRATE_TO_AMM":
+                self.migrated_to_amm = True
+                self.migrate_value = ins.operand
             else:
                 raise ValueError(f"Unknown opcode: {ins.opcode}")

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -23,3 +23,22 @@ def test_buy_pipeline_and_post():
     tx_sig = poster.commit(program)
     # Ensure commit returned the base64-encoded payload
     assert tx_sig == client.sent[-1]
+
+
+def test_all_opcodes_pipeline():
+    script = """BUY 5
+SELL 2
+ADD_LIQUIDITY 3
+MIGRATE_TO_AMM 1"""
+    ast = parse(script)
+    program = compile_program(ast)
+    vm = CurveVM()
+    vm.execute(program)
+    assert vm.balance == 3
+    assert vm.liquidity == 3
+    assert vm.migrated_to_amm is True
+
+    client = FakeSolanaClient()
+    poster = BatchPoster(client)
+    tx_sig = poster.commit(program)
+    assert tx_sig == client.sent[-1]


### PR DESCRIPTION
## Summary
- extend CurveScript parser for SELL, ADD_LIQUIDITY and MIGRATE_TO_AMM
- compile all opcodes in compiler
- execute them in CurveVM
- update README example
- test end-to-end flow for all opcodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687660e550f88333822374f07c6c5b0e