### PR TITLE
Add AssetSequencer-BFT skeleton and tests

### DIFF
--- a/src/asset_sequencer_bft/__init__.py
+++ b/src/asset_sequencer_bft/__init__.py
@@ -1,0 +1,4 @@
+from .consensus import Consensus, Block
+from .leader_schedule import round_robin
+
+__all__ = ["Consensus", "Block", "round_robin"]

--- a/src/asset_sequencer_bft/consensus.py
+++ b/src/asset_sequencer_bft/consensus.py
@@ -1,0 +1,50 @@
+import json
+import hashlib
+from dataclasses import dataclass
+from typing import List
+
+from ..curvevm import CurveVM
+from ..compiler import Instruction
+from ..rollup import BatchPoster
+from .leader_schedule import round_robin
+
+
+@dataclass
+class Block:
+    program: List[Instruction]
+
+
+def _state_root(program: List[Instruction]) -> str:
+    vm = CurveVM()
+    vm.execute(program)
+    state = {
+        "balance": vm.balance,
+        "liquidity": vm.liquidity,
+        "migrated": vm.migrated_to_amm,
+        "migrate_value": vm.migrate_value,
+    }
+    data = json.dumps(state, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+class Consensus:
+    """A minimal two-phase HotStuff-like loop."""
+
+    def __init__(self, validators: List[str], poster: BatchPoster) -> None:
+        if len(validators) < 1:
+            raise ValueError("Need at least one validator")
+        self.validators = validators
+        self.poster = poster
+        self._schedule = round_robin(validators)
+        self.height = 0
+
+    def propose_and_commit(self, block: Block) -> str:
+        leader = next(self._schedule)
+        # Each validator executes the block to compute a state root
+        roots = {_state_root(block.program) for _ in self.validators}
+        if len(roots) != 1:
+            raise ValueError("State roots diverged")
+        # Post to Solana via BatchPoster
+        tx_sig = self.poster.commit(block.program)
+        self.height += 1
+        return tx_sig

--- a/src/asset_sequencer_bft/leader_schedule.py
+++ b/src/asset_sequencer_bft/leader_schedule.py
@@ -1,0 +1,11 @@
+from typing import Iterable, Iterator, List
+
+
+def round_robin(validators: List[str]) -> Iterator[str]:
+    """Yield validator ids in a deterministic round-robin schedule."""
+    if not validators:
+        raise ValueError("No validators provided")
+    i = 0
+    while True:
+        yield validators[i % len(validators)]
+        i += 1

--- a/src/rollup.py
+++ b/src/rollup.py
@@ -1,6 +1,7 @@
 import base64
 import json
 from typing import List
+import hashlib
 
 from .compiler import Instruction
 
@@ -21,9 +22,12 @@ class BatchPoster:
         self.client = client
 
     def commit(self, program: List[Instruction]) -> str:
-        # Serialize program as JSON for this demo
-        payload = json.dumps([
+        """Serialize the program, compute a Merkle-style root and post it."""
+        instr_list = [
             {"op": ins.opcode, "arg": ins.operand} for ins in program
-        ]).encode("utf-8")
+        ]
+        encoded = json.dumps(instr_list, sort_keys=True).encode("utf-8")
+        root = hashlib.sha256(encoded).hexdigest()
+        payload = json.dumps({"root": root, "program": instr_list}).encode("utf-8")
         # Send to Solana (stubbed)
         return self.client.send_transaction(payload)

--- a/tests/test_bft.py
+++ b/tests/test_bft.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import base64
+import json
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.curvescript import parse
+from src.compiler import compile_program
+from src.rollup import FakeSolanaClient, BatchPoster
+from src.asset_sequencer_bft import Consensus, Block, round_robin
+
+
+def test_round_robin_schedule():
+    vals = ["A", "B", "C"]
+    sched = round_robin(vals)
+    assert [next(sched) for _ in range(5)] == ["A", "B", "C", "A", "B"]
+
+
+def test_consensus_commit():
+    script = "BUY 1"
+    program = compile_program(parse(script))
+
+    client = FakeSolanaClient()
+    poster = BatchPoster(client)
+    consensus = Consensus(["A", "B", "C"], poster)
+    block = Block(program=program)
+
+    tx = consensus.propose_and_commit(block)
+    assert tx == client.sent[-1]
+    payload = json.loads(base64.b64decode(tx).decode("utf-8"))
+    encoded = json.dumps(payload["program"], sort_keys=True).encode("utf-8")
+    expected_root = hashlib.sha256(encoded).hexdigest()
+    assert payload["root"] == expected_root

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import json
+import base64
+import hashlib
 
 # Ensure src is on the path when running tests from GitHub Actions
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -21,15 +24,15 @@ def test_buy_pipeline_and_post():
     client = FakeSolanaClient()
     poster = BatchPoster(client)
     tx_sig = poster.commit(program)
-    # Ensure commit returned the base64-encoded payload
     assert tx_sig == client.sent[-1]
+    payload = json.loads(base64.b64decode(tx_sig).decode("utf-8"))
+    encoded = json.dumps(payload["program"], sort_keys=True).encode("utf-8")
+    expected_root = hashlib.sha256(encoded).hexdigest()
+    assert payload["root"] == expected_root
 
 
 def test_all_opcodes_pipeline():
-    script = """BUY 5
-SELL 2
-ADD_LIQUIDITY 3
-MIGRATE_TO_AMM 1"""
+    script = """BUY 5\nSELL 2\nADD_LIQUIDITY 3\nMIGRATE_TO_AMM 1"""
     ast = parse(script)
     program = compile_program(ast)
     vm = CurveVM()
@@ -42,3 +45,8 @@ MIGRATE_TO_AMM 1"""
     poster = BatchPoster(client)
     tx_sig = poster.commit(program)
     assert tx_sig == client.sent[-1]
+    payload = json.loads(base64.b64decode(tx_sig).decode("utf-8"))
+    encoded = json.dumps(payload["program"], sort_keys=True).encode("utf-8")
+    expected_root = hashlib.sha256(encoded).hexdigest()
+    assert payload["root"] == expected_root
+


### PR DESCRIPTION
## Summary
- add `asset_sequencer_bft` package with round-robin leader schedule and minimal consensus
- extend `BatchPoster.commit` to include a hash root of instructions
- verify Merkle-style root in end-to-end tests
- add BFT tests for leader rotation and consensus commit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687676962c6083339e6f1baa459ea455