### PR TITLE
Update migration progress to mention Python tests

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -43,4 +43,4 @@ This phased approach retains the current Python prototype as a specification whi
 
 ## Migration progress
 
-The repository now contains Rust crates for the CurveVM, compiler, sequencer, HotShot-based consensus and an Anchor rollup program.  Unit tests cover the mempool, miner and consensus logic.  A GitHub Actions workflow runs `cargo test` for CI.
+The repository now contains Rust crates for the CurveVM, compiler, sequencer, HotShot-based consensus and an Anchor rollup program.  Unit tests cover the mempool, miner and consensus logic. A GitHub Actions workflow runs `cargo test` for CI. The original Python modules remain under `src/` with a pytest suite to ensure behavior parity.


### PR DESCRIPTION
## Summary
- note that the original Python modules and pytest suite remain

## Testing
- `cargo test --workspace --all-targets`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687758c71afc8333accf6d5d3bdd33e1