### PR TITLE
Add assetvm and assetscript crates with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assetscript"
+version = "0.1.0"
+dependencies = [
+ "assetvm",
+ "borsh 0.10.4",
+]
+
+[[package]]
+name = "assetvm"
+version = "0.1.0"
+dependencies = [
+ "borsh 0.10.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
     "curvevm",
     "compiler",
+    "assetvm",
+    "assetscript",
     "sequencer",
     "asset_rollup_program", "hotshot",
 ]

--- a/assetscript/Cargo.toml
+++ b/assetscript/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "assetscript"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+assetvm = { path = "../assetvm" }
+borsh = "0.10"

--- a/assetscript/src/lib.rs
+++ b/assetscript/src/lib.rs
@@ -1,0 +1,61 @@
+use assetvm::{Instruction, Opcode};
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct Command {
+    pub opcode: String,
+    pub amount: i64,
+}
+
+pub fn parse(script: &str) -> Result<Vec<Command>, String> {
+    let mut cmds = Vec::new();
+    let allowed = ["MINT", "TRANSFER", "BURN"];
+    for line in script.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<_> = line.split_whitespace().collect();
+        if parts.len() != 2 || !allowed.contains(&parts[0].to_ascii_uppercase().as_str()) {
+            return Err(format!("Invalid statement: {}", line));
+        }
+        let amount: i64 = parts[1]
+            .parse()
+            .map_err(|_| format!("Invalid amount in: {}", line))?;
+        cmds.push(Command { opcode: parts[0].to_ascii_uppercase(), amount });
+    }
+    Ok(cmds)
+}
+
+pub fn compile(commands: &[Command]) -> Result<Vec<Instruction>, String> {
+    commands
+        .iter()
+        .map(|cmd| {
+            let op = match cmd.opcode.as_str() {
+                "MINT" => Opcode::Mint,
+                "TRANSFER" => Opcode::Transfer,
+                "BURN" => Opcode::Burn,
+                other => return Err(format!("Unknown command: {}", other)),
+            };
+            Ok(Instruction { opcode: op, amount: cmd.amount })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assetvm::{AssetVM, program_root};
+
+    #[test]
+    fn parse_compile_execute_pipeline() {
+        let script = "MINT 5\nTRANSFER 3\nBURN 1";
+        let cmds = parse(script).unwrap();
+        let program = compile(&cmds).unwrap();
+        let mut vm = AssetVM::new();
+        vm.execute(&program);
+        assert_eq!(vm.supply, 4);
+        assert_eq!(vm.last_transfer, 3);
+        let _root = program_root(&program);
+    }
+}

--- a/assetvm/Cargo.toml
+++ b/assetvm/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "assetvm"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+borsh = "0.10"
+sha2 = "0.10"

--- a/assetvm/src/lib.rs
+++ b/assetvm/src/lib.rs
@@ -1,0 +1,67 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[repr(u8)]
+pub enum Opcode {
+    Mint,
+    Transfer,
+    Burn,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct Instruction {
+    pub opcode: Opcode,
+    pub amount: i64,
+}
+
+pub struct AssetVM {
+    pub supply: i64,
+    pub last_transfer: i64,
+}
+
+impl AssetVM {
+    pub fn new() -> Self {
+        Self { supply: 0, last_transfer: 0 }
+    }
+
+    pub fn execute(&mut self, program: &[Instruction]) {
+        for ins in program {
+            match ins.opcode {
+                Opcode::Mint => self.supply += ins.amount,
+                Opcode::Transfer => self.last_transfer = ins.amount,
+                Opcode::Burn => self.supply -= ins.amount,
+            }
+        }
+    }
+}
+
+pub fn program_root(program: &[Instruction]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    for ins in program {
+        hasher.update(&[ins.opcode as u8]);
+        hasher.update(ins.amount.to_le_bytes());
+    }
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_execution_and_root() {
+        let program = [
+            Instruction { opcode: Opcode::Mint, amount: 5 },
+            Instruction { opcode: Opcode::Transfer, amount: 2 },
+            Instruction { opcode: Opcode::Burn, amount: 1 },
+        ];
+        let mut vm = AssetVM::new();
+        vm.execute(&program);
+        assert_eq!(vm.supply, 4);
+        assert_eq!(vm.last_transfer, 2);
+        let r1 = program_root(&program);
+        let r2 = program_root(&program);
+        assert_eq!(r1, r2);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `assetvm` crate implementing a simple VM for mint/transfer/burn
- add new `assetscript` crate for parsing and compiling asset scripts
- wire crates into workspace
- include unit tests demonstrating end‑to‑end usage

## Testing
- `cargo test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68775ee8fdfc8333a88478ec0f58e7a6