### PR TITLE
Rewrite migration plan for HotShot testing

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,46 +1,41 @@
-# Asset L2 Rust Migration Plan
+# Asset L2 Migration & Testnet Plan
 
-This document sketches a high level path to migrate the experimental Python prototype to production grade Rust tooling.  It focuses on two core pieces:
+This document replaces the previous migration notes. It captures the decisions from recent discussion and describes how to bring Asset L2 to a HotShot-based testnet with $ASSET as the native token.
 
-1. **Solana on-chain programs.**
-2. **The off-chain sequencer and BFT consensus.**
+## Goals
+- **Pure Rust stack.** All on‑chain and off‑chain components are written in Rust.
+- **HotShot consensus.** Use Espresso's HotShot implementation for BFT.
+- **Automated testing.** Adopt HotShot's own `hotshot-testing` crate and `cargo nextest` for network tests.
+- **Launch a public testnet** running the sequencer and Anchor program.
 
-## 1. Solana programs
+## 1. On‑chain program
+- Build the batch verification contract using Anchor and `solana-program`.
+- Provide serialization via Borsh. The existing `asset_rollup_program` crate is the foundation.
+- Deploy to Solana devnet first, then upgrade to testnet.
 
-- **Use the Anchor framework** (`anchor-lang`, `anchor-client`) for program development, testing and deployment. Anchor is widely adopted in the Solana ecosystem and provides audited primitives for PDAs, CPI calls and serialization.
-- **Leverage the official `solana-program` crate** for low level runtime interfaces.
-- Re-write CurveVM as a Rust crate that can compile to both native binaries (for off-chain simulation) and a Solana program module.
-- For serialization of instructions and state roots, use the `borsh` or `anchor` provided macros.
+## 2. Sequencer & BFT
+- Implement networking with `tokio` and `libp2p`.
+- Integrate HotShot as the consensus engine. The `hotshot` crate in this repo is a starting point.
+- The sequencer posts state roots to the on‑chain program every block (≈250 ms).
+- Run a committee of five‑to‑seven validators for the testnet.
 
-## 2. Off-chain sequencer & BFT
+## 3. Testing approach
+- Add `hotshot-testing` as a dev‑dependency.
+- Use `cargo nextest` to run both unit and integration tests. Mirror HotShot’s `just` tasks if desired.
+- Write integration tests that spin up multiple HotShot nodes via `TestBuilder` and verify deterministic state roots and block commits.
+- Keep existing unit tests to ensure VM and compiler correctness.
 
-- **Networking and async tasks** – base the service on `tokio` and `libp2p`. These crates are well maintained and battle tested in many blockchain projects.
-- **Mempool** – adopt persistent data structures such as `dashmap` for concurrent access, optionally backed by `sled` or `rocksdb` for disk durability.
-- **BFT consensus** – evaluate existing Rust implementations:
-  - [HotShot](https://github.com/EspressoSystems/espresso-sequencer) – an open source HotStuff-based BFT engine used by Espresso. It is actively developed and packaged as reusable crates.
-  - [CometBFT](https://github.com/cometbft/cometbft) – a Go implementation of Tendermint; bindings exist but would introduce a cross-language dependency.
-  Given the desire for a pure Rust stack, HotShot is the natural starting point.
-- **Transaction posting** – use the `solana-sdk` and `solana-client` crates to submit batch roots to the AssetRollup program on Solana.
+## 4. Continuous Integration
+- Run `cargo fmt -- --check` and `cargo clippy -- -D warnings` in CI.
+- Use `cargo nextest` in CI to execute the full test suite.
+- Include a license file and set `license = "MIT"` (or chosen license) in each `Cargo.toml`.
 
-## 3. Rollup frameworks
+## 5. Launching a testnet
+1. **Build** all crates with `cargo build --workspace`.
+2. **Run tests** with `cargo nextest run --workspace` to ensure both unit and integration tests pass.
+3. **Deploy** the Anchor program to Solana devnet using `anchor deploy`.
+4. **Start the sequencer**: launch several HotShot nodes that connect via `libp2p` and post batches through `BatchPoster`.
+5. **Mint $ASSET** using the `assetvm` logic and exercise transfers via CurveVM programs.
+6. **Monitor** state roots and validator performance. Iterate until stable, then open the network to external testers.
 
-There is not yet a widely adopted "Solana rollup SDK." The ecosystem is evolving and several projects are building generic rollup toolkits:
-
-- [Rollkit](https://github.com/rollkit/rollkit) – a sovereign rollup framework in Go used with Celestia for data availability.
-- [Sovereign SDK](https://github.com/sovereign-labs/sovereign-sdk) – a Rust-based toolkit for optimistic and zk rollups that is still under heavy development.
-
-While these frameworks are not Solana-specific, they offer reusable components (DA layers, state trees, proof systems) that could be adapted. Anchor and the Solana runtime remain the most production tested choice for writing programs that interact with Solana today.
-
-## 4. Migration steps
-
-1. **Define Rust crates** for `curvevm`, `compiler`, `sequencer`, and `solana-program` modules.
-2. **Port tests** from `pytest` to Rust's `cargo test` framework.
-3. **Integrate HotShot** as the consensus engine and connect it to the Rust mempool and miner logic.
-4. **Use Anchor** to implement the on-chain batch verification program.
-5. **Automate builds** with `cargo` and set up CI (e.g., GitHub Actions) to run `cargo fmt`, `clippy`, and tests.
-
-This phased approach retains the current Python prototype as a specification while the Rust rewrite matures. Once feature parity is reached, deprecate the Python modules and rely solely on the Rust crates for production.
-
-## Migration progress
-
-The repository now contains Rust crates for the CurveVM, compiler, sequencer, HotShot-based consensus and an Anchor rollup program.  Unit tests cover the mempool, miner and consensus logic. A GitHub Actions workflow runs `cargo test` for CI. The original Python modules remain under `src/` with a pytest suite to ensure behavior parity.
+Following this plan brings Asset L2 from the current prototype to a fully tested HotShot‑backed testnet running the $ASSET token.


### PR DESCRIPTION
## Summary
- replace existing migration plan with new roadmap
- outline HotShot-based testing and testnet steps

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_687760dc604883339004e20e9d5b74fc